### PR TITLE
Fight API breakage in zeroconf, fix #7

### DIFF
--- a/touchosc2midi/advertise.py
+++ b/touchosc2midi/advertise.py
@@ -33,7 +33,7 @@ def build_service_info(ip):
     """Create a zeroconf ServiceInfo for touchoscbridge
     on for `ip` or the guessed default route interface's IP.
     """
-    return ServiceInfo(type=TOUCHOSC_BRIDGE,
+    return ServiceInfo(type_=TOUCHOSC_BRIDGE,
                        name="{}.{}".format(socket.gethostname(), TOUCHOSC_BRIDGE),
                        address=socket.inet_aton(ip),
                        port=PORT,


### PR DESCRIPTION
The first parameter to `ServiceInfo.__init__()` was renamed to `type_` [a month ago](https://github.com/jstasiak/python-zeroconf/commit/6b39c70fa1ed7cfac89e02e2b3764a9038b87267)
