### PR TITLE
touchosc2midi.py: Fix for --ip argument.

### DIFF
--- a/touchosc2midi/touchosc2midi.py
+++ b/touchosc2midi/touchosc2midi.py
@@ -112,7 +112,7 @@ def main():
             psa = Advertisement(ip=options.get('--ip'))
             psa.register()
 
-            target_address = wait_for_target_address()
+            target_address = wait_for_target_address(psa.ip)
 
             log.debug("Listening for touchOSC on {}:{}.".format(psa.ip, PORT))
             server = liblo.ServerThread(PORT)


### PR DESCRIPTION
This patch fixes --ip argument. Otherwise, the 'guessed' ip address is used and the provided IP argument is not respected.