### PR TITLE
Fix crash in main_ip on macOS

### DIFF
--- a/touchosc2midi/advertise.py
+++ b/touchosc2midi/advertise.py
@@ -22,7 +22,7 @@ def main_ip():
     :return: the IP of the default route's interface.
     """
     sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-    sock.connect(("192.0.2.0", 0))
+    sock.connect(("192.0.2.0", 1))
     ip = sock.getsockname()[0]
     log.debug("Assuming {} for main route's IP.".format(ip))
     sock.close()


### PR DESCRIPTION
On macOS when run without ```--ip``` it fails in ```main_ip```:
```
Traceback (most recent call last):
  File "/usr/local/bin/touchosc2midi", line 11, in <module>
    load_entry_point('touchosc2midi==0.0.10a0', 'console_scripts', 'touchosc2midi')()
  File "/usr/local/lib/python2.7/site-packages/touchosc2midi/touchosc2midi.py", line 160, in main
    psa = Advertisement(ip=options.get('--ip'))
  File "/usr/local/lib/python2.7/site-packages/touchosc2midi/advertise.py", line 54, in __init__
    self.info = build_service_info(ip=ip or main_ip())
  File "/usr/local/lib/python2.7/site-packages/touchosc2midi/advertise.py", line 25, in main_ip
    sock.connect(("192.0.2.0", 0))
  File "/usr/local/Cellar/python/2.7.13/Frameworks/Python.framework/Versions/2.7/lib/python2.7/socket.py", line 228, in meth
    return getattr(self._sock,name)(*args)
socket.error: [Errno 49] Can't assign requested address
```

Changing the port from 0 to anything else fixes this. 

I also tested on Raspian and Debian and both seem to be fine with any port number, so it seems a harmless change that brings more macOS compatibility.