### PR TITLE
Fixes for newer required libraries

### DIFF
--- a/touchosc2midi/advertise.py
+++ b/touchosc2midi/advertise.py
@@ -37,7 +37,7 @@ def build_service_info(ip):
                            socket.gethostname(),
                            TOUCHOSC_BRIDGE
                        ),
-                       address=socket.inet_aton(ip),
+                       addresses=[socket.inet_aton(ip)],
                        port=PORT,
                        properties=dict(),
                        server=socket.gethostname() + '.local.')
@@ -86,7 +86,8 @@ class Advertisement(object):
     def get_ip(self):
         """:return: the service's IP as a string.
         """
-        return socket.inet_ntoa(self.info.address)
+        return socket.inet_ntoa(self.info.addresses[0]) \
+            if len(self.info.addresses) > 0 else "--none--"
 
     ip = property(get_ip)
 

--- a/touchosc2midi/configuration.py
+++ b/touchosc2midi/configuration.py
@@ -76,6 +76,9 @@ def configure_ioports(backend, virtual=True, mido_in=None, mido_out=None):
             # we have to init with dummy callback, there seems to be a bug in mido
             midi_in = backend.open_input(VIRT_MIDI_PORT, virtual=True, callback=lambda x: x)
             midi_out = backend.open_output(VIRT_MIDI_PORT, virtual=True)
+            # work around bug in mido prior to 1.3.0
+            if backend.api == 'LINUX_ALSA':
+                midi_out._rt.set_port_name(VIRT_MIDI_PORT)
         except ImportError:
             log.error("Cannot open virtual IOports. Make sure, rtmidi is available"
                       "or choose another backend.")


### PR DESCRIPTION
These two fixes address problems with touchosc2midi when trying to get it to run with current Debian (12 Bookworm) python3 packages for the requirements.

The first handles a breaking API change in Zeroconf, that happened in 0.27.0.
 * requirements.txt lists 0.17.7
 * Debian 12 Bookworm has 0.47.3

The second handles a bug in mido when using rt-midi/ALSA as the backend, which causes awful port names(*).
 * requirements.txt lists 1.1.24, which doesn't have the bug.
 * The bug was introduced in 1.2.0, then fixed in mido 1.3.0.
 * Alas, Debian 12 Bookworm, and all upcoming Debian releases, have 1.2.10

----
(*): Just how awful? Here's the ports touchosc2midi creates when using mido 1.2.10:
```
    RtMidiIn Client  : TouchOSC Bridge                       [129:0] <--
    RtMidiOut Client : RtMidiIn Client:TouchOSC Bridge 129:0 [130:0] -->
```
Yep - the whole string **RtMidiIn Client:TouchOSC Bridge 129:0** is the _output_ port name!

